### PR TITLE
Patch reaction int64 string

### DIFF
--- a/Report-System/cancelReport.go
+++ b/Report-System/cancelReport.go
@@ -38,11 +38,13 @@
                             {{$report.Set $k (structToSdict $v)}}
                         {{end}}
                     {{end}}
+                    {{$user := userArg (dbGet $reportMessageID "reportAuthor").Value}}
                     {{with $report}}
                         {{.Author.Set "Icon_URL" $report.Author.IconURL}} 
                         {{.Footer.Set "Icon_URL" $report.Footer.IconURL}}
                         {{.Set "description" $combinedString}}
                         {{.Set "color" 16711935}}
+                        {{$.Set "Author" (sdict "text" (print $user.String "(ID" $user.ID ")") "icon_url" ($user.AvatarURL "256"))}}
                         {{.Set "Fields" ((cslice).AppendSlice .Fields)}}{{.Fields.Set 4 (sdict "name" "Reaction Menu Options" "value" $cancelGuide)}}
                     {{end}}
                     {{editMessage $reportLog $reportMessageID (complexMessageEdit "embed" $report)}}

--- a/Report-System/customReport.go
+++ b/Report-System/customReport.go
@@ -73,7 +73,7 @@
         {{addMessageReactions $reportLog $x "❌" "🛡️" "⚠️"}}
         {{sendMessage nil "User reported to the proper authorites!"}}
         {{dbSet .User.ID "key" $secret}}
-        {{dbSet $x "reportAuthor" (toString .User.ID)}}
+        {{dbSet $x "reportAuthor" (toString .User.Mention)}}
         {{deleteTrigger}}
         {{deleteResponse}}
         {{sendDM (printf "User reported to the proper authorities! If you wish to cancel your report, simply type `-cancelr %d %s` in any channel.\n **A reason is required.**" $x $secret)}}

--- a/Report-System/customReport.go
+++ b/Report-System/customReport.go
@@ -21,7 +21,7 @@
 
 
 {{/*ACTUAL CODE*/}}
-{{$isAdmin := false}} {{range .Member.Roles}} {{if in $adminRoles .}} {{$isAdmin = true}} {{end}} {{end}}
+{{$isAdmin := false}}{{range .Member.Roles}}{{if in $adminRoles .}}{{$isAdmin = true}}{{end}}{{end}}
 {{if (eq (len .CmdArgs) 1)}}
     {{if eq (index .CmdArgs 0) "dbSetup"}}
         {{if $isAdmin}}
@@ -54,7 +54,7 @@
         {{$reportGuide := (printf "\nDismiss report with ❌, put under investigation with 🛡️, or request more background information with ⚠️.")}}
         {{$userReportString := (printf  "<@%d> reported <@%d> in <#%d>." .User.ID $user.ID .Channel.ID)}}
         {{dbSet 2000 "reportGuideBasic" $reportGuide}}
-        {{dbSet 2000 (printf "userReport%d" .User.ID) $userReportString}}
+        {{dbSet .User.ID "userReport" $userReportString}}
         {{$reportNo := dbIncr 2000 "ReportNo" 1}}
         {{$reportEmbed := cembed "title" (print "Report No. " $reportNo)
             "author" (sdict "name" (printf "%s (ID %d)" .User.String .User.ID) "icon_url" (.User.AvatarURL "256"))

--- a/Report-System/reactionHandler.go
+++ b/Report-System/reactionHandler.go
@@ -1,21 +1,10 @@
-{{/*
-    This handy-dandy custom command-bundle allows a user to cancel their most recent report and utilizes
-    Reactions to make things easier for staff.
-    This custom command manages the reaction menu.
-    Make this in a seperate Reaction CC, due to its massive character count.
-    Remove this leading comment once you added this command.
-
-    Obligatory Trigger type and trigger: Reaction; added reactions only.
-
-    Created by: Olde#7325
-*/}}
 {{/*ACTUAL CODE*/}}
 {{/*Validation steps*/}}
 {{$reportLog := (dbGet 2000 "reportLog").Value|toInt64}}
 {{$reportDiscussion := (dbGet 2000 "reportDiscussion").Value|toInt64}}
 {{if eq .Reaction.ChannelID $reportLog}}
 {{/*Set some vars, cutting down on DB stuff, Readability shit*/}}
-{{$reportGuide := ((dbGet 2000 "reportGuideBasic").Value|str)}}{{$user := (toInt64 (dbGet .Reaction.MessageID "reportAuthor").Value)}}{{$userReportString := ((dbGet 2000 (printf "userReport%d" $user)).Value|str)}}
+{{$reportGuide := ((dbGet 2000 "reportGuideBasic").Value|str)}}{{$user := userArg (dbGet .Reaction.MessageID "reportAuthor").Value}}{{$userReportString := ((dbGet 2000 (printf "userReport%d" $user)).Value|str)}}
 {{$userCancelString := ((dbGet 2000 (printf "userCancel%d" $user)).Value|str)}}{{$mod := (printf "\nResponsible moderator: <@%d>" .Reaction.UserID)}}{{$modRoles := (cslice).AppendSlice (dbGet 2000 "modRoles").Value}}
 {{$isMod := false}} {{range .Member.Roles}} {{if in $modRoles .}} {{$isMod = true}}{{end}}{{end}}
 {{$report := index (getMessage nil .Reaction.MessageID).Embeds 0|structToSdict}}{{range $k, $v := $report}}{{if eq (kindOf $v true) "struct"}}{{$report.Set $k (structToSdict $v)}}{{end}}{{end}}

--- a/Report-System/reactionHandler.go
+++ b/Report-System/reactionHandler.go
@@ -1,11 +1,20 @@
+{{/*
+    This handy-dandy custom command-bundle allows a user to cancel their most recent report and utilizes
+    Reactions to make things easier for staff.
+    This custom command manages the reaction menu.
+    Make this in a seperate Reaction CC, due to its massive character count.
+    Remove this leading comment once you added this command.
+    Obligatory Trigger type and trigger: Reaction; added reactions only.
+    Created by: Olde#7325
+*/}}
 {{/*ACTUAL CODE*/}}
 {{/*Validation steps*/}}
 {{$reportLog := (dbGet 2000 "reportLog").Value|toInt64}}
 {{$reportDiscussion := (dbGet 2000 "reportDiscussion").Value|toInt64}}
 {{if eq .Reaction.ChannelID $reportLog}}
 {{/*Set some vars, cutting down on DB stuff, Readability shit*/}}
-{{$reportGuide := ((dbGet 2000 "reportGuideBasic").Value|str)}}{{$user := userArg (dbGet .Reaction.MessageID "reportAuthor").Value}}{{$userReportString := ((dbGet 2000 (printf "userReport%d" $user)).Value|str)}}
-{{$userCancelString := ((dbGet 2000 (printf "userCancel%d" $user)).Value|str)}}{{$mod := (printf "\nResponsible moderator: <@%d>" .Reaction.UserID)}}{{$modRoles := (cslice).AppendSlice (dbGet 2000 "modRoles").Value}}
+{{$reportGuide := ((dbGet 2000 "reportGuideBasic").Value|str)}}{{$user := userArg (dbGet .Reaction.MessageID "reportAuthor").Value}}{{$userReportString := ((dbGet 2000 (printf "userReport%d" $user.ID)).Value|str)}}
+{{$userCancelString := ((dbGet 2000 (printf "userCancel%d" $user.ID)).Value|str)}}{{$mod := (printf "\nResponsible moderator: <@%d>" .Reaction.UserID)}}{{$modRoles := (cslice).AppendSlice (dbGet 2000 "modRoles").Value}}
 {{$isMod := false}} {{range .Member.Roles}} {{if in $modRoles .}} {{$isMod = true}}{{end}}{{end}}
 {{$report := index (getMessage nil .Reaction.MessageID).Embeds 0|structToSdict}}{{range $k, $v := $report}}{{if eq (kindOf $v true) "struct"}}{{$report.Set $k (structToSdict $v)}}{{end}}{{end}}
 {{if $isMod}}
@@ -14,14 +23,14 @@
     {{if (dbGet .Reaction.MessageID "ModeratorID")}}
         {{if eq .User.ID (toInt64 (dbGet .Reaction.MessageID "ModeratorID").Value)}}
             {{if eq .Reaction.Emoji.Name "❌"}}{{/*Dismissal*/}}
-                {{sendMessage $reportDiscussion (printf "<@%d>: Your report was dismissed. %s" $user $mod)}}
+                {{sendMessage $reportDiscussion (printf "<@%d>: Your report was dismissed. %s" $user.ID $mod)}}
                 {{deleteAllMessageReactions nil .Reaction.MessageID}}
                 {{$report.Set "Fields" ((cslice).AppendSlice $report.Fields)}}{{$report.Fields.Set 0 (sdict "name" "Current State" "value" "__Report dismissed.__")}}
                 {{$report.Set "Fields" ((cslice).AppendSlice $report.Fields)}}{{$report.Fields.Set 4 (sdict "name" "Reaction Menu Options" "value" "Warn for `False report` with ❗ or finish without warning with 👌.")}}
                 {{$report.Set "color" 65280}}
                 {{editMessage nil .Reaction.MessageID (complexMessageEdit "embed" $report)}}
                 {{addReactions "❗" "👌"}}
-                {{dbSet $user "key" "used"}}
+                {{dbSet $user.ID "key" "used"}}
             {{else if eq .Reaction.Emoji.Name "🛡️"}}{{/*Taking care*/}}
                 {{sendMessage $reportDiscussion (printf "<@%d>: Your report is being taken care of; Should you have any further information, please post it down below. %s" $user $mod)}}
                 {{deleteAllMessageReactions nil .Reaction.MessageID}}
@@ -30,9 +39,9 @@
                 {{$report.Set "color" 16776960}}
                 {{editMessage nil .Reaction.MessageID (complexMessageEdit "embed" $report)}}
                 {{addReactions "❌" "👍"}}
-                {{dbSet $user "key" "used"}}
+                {{dbSet $user.ID "key" "used"}}
             {{else if eq .Reaction.Emoji.Name "⚠️"}}{{/*Request info*/}}
-                {{if not (eq ((dbGet $user "key").Value) "used")}}{{/*Without cancellation request*/}}
+                {{if ne (dbGet $user.ID "key").Value "used"}}{{/*Without cancellation request*/}}
                     {{sendMessage $reportDiscussion (printf "<@%d>: More information was requested. Please post it down below. %s" $user $mod)}}
                     {{deleteAllMessageReactions nil .Reaction.MessageID}}
                     {{$report.Set "Fields" ((cslice).AppendSlice $report.Fields)}}{{$report.Fields.Set 0 (sdict "name" "Current State" "value" "__More information requested.__")}}
@@ -77,7 +86,7 @@
                 {{dbDel .Reaction.MessageID "ModeratorID"}}
                 {{addReactions "🏳️"}}
             {{else if eq .Reaction.Emoji.Name "❗"}}
-                {{$silent := exec "warn" $user "False Report."}}
+                {{$silent := exec "warn" $user.ID "False Report."}}
                 {{deleteAllMessageReactions nil .Reaction.MessageID}}
                 {{$report.Set "Fields" ((cslice).AppendSlice $report.Fields)}}{{$report.Fields.Set 0 (sdict "name" "Current State" "value" "__Report dismissed, warned for false report.__")}}
                 {{$report.Set "Fields" ((cslice).AppendSlice (slice $report.Fields 0 4))}}


### PR DESCRIPTION
This pull request fixes the issue caused by storing the User ID instead of the User-Object. We now store the Object and therefore have all the User-Templates available in every command.